### PR TITLE
Oppdaterer scope for dokdistfordeling

### DIFF
--- a/.nais/feature.yaml
+++ b/.nais/feature.yaml
@@ -17,6 +17,7 @@ env:
   DOKARKIV_URL: https://dokarkiv-q1.dev.intern.nav.no/
   DOKARKIV_KNYTT_TIL_SAK_URL: https://dokarkiv-q1.dev.intern.nav.no
   DOKDISTFORDELING_URL: https://dokdistfordeling-q1.dev.intern.nav.no
+  DOKDISTFORDELING_SCOPE: dev-fss.teamdokumenthandtering.dokdistfordeling-q1
   SAF_URL: https://saf-q1.dev.intern.nav.no
   OPPGAVE_URL: https://oppgave-q1.dev.intern.nav.no/api/v1/oppgaver
   OPPGAVE_SCOPE: dev-fss.oppgavehandtering.oppgave-q1

--- a/.nais/main.yaml
+++ b/.nais/main.yaml
@@ -17,6 +17,7 @@ env:
   DOKARKIV_URL: https://dokarkiv-q2.dev.intern.nav.no/
   DOKARKIV_KNYTT_TIL_SAK_URL: https://dokarkiv-q2.dev.intern.nav.no
   DOKDISTFORDELING_URL: https://dokdistfordeling-q2.dev.intern.nav.no
+  DOKDISTFORDELING_SCOPE: dev-fss.teamdokumenthandtering.dokdistfordeling
   SAF_URL: https://saf-q2.dev.intern.nav.no
   OPPGAVE_URL: https://oppgave.dev.intern.nav.no/api/v1/oppgaver
   OPPGAVE_SCOPE: dev-fss.oppgavehandtering.oppgave

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -18,6 +18,7 @@ env:
   DOKARKIV_URL: https://dokarkiv.intern.nav.no/
   DOKARKIV_KNYTT_TIL_SAK_URL: https://dokarkiv.intern.nav.no
   DOKDISTFORDELING_URL: https://dokdistfordeling.intern.nav.no
+  DOKDISTFORDELING_SCOPE: prod-fss.teamdokumenthandtering.dokdistfordeling
   SAF_URL: https://saf.intern.nav.no
   OPPGAVE_URL: https://oppgave.nais.adeo.no/api/v1/oppgaver
   OPPGAVE_SCOPE: prod-fss.oppgavehandtering.oppgave

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -76,7 +76,7 @@ no.nav.security.jwt:
         resource-url: ${DOKDISTFORDELING_URL}
         token-endpoint-url: https://login.microsoftonline.com/${AZURE_APP_TENANT_ID}/oauth2/v2.0/token
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
-        scope: api://${SAF_SCOPE}/.default
+        scope: api://${DOKDISTFORDELING_SCOPE}/.default
         authentication:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}

--- a/src/test/resources/application-local.yaml
+++ b/src/test/resources/application-local.yaml
@@ -23,7 +23,7 @@ SAF_SCOPE: dev-fss.teamdokumenthandtering.saf-q1
 PERSON_SCOPE: dev-fss.bidrag.bidrag-person-feature
 ORGANISASJON_SCOPE: dev-fss.bidrag.bidrag-organisasjon-feature
 DOKARKIV_SCOPE: dev-fss.teamdokumenthandtering.dokarkiv-q1
-
+DOKDISTFORDELING_SCOPE: dev-fss.teamdokumenthandtering.dokdistfordeling-q1
 
 ACCESS_TOKEN_URL: https://security-token-service.dev.adeo.no
 AKTORREGISTER_URL: https://app-q1.adeo.no/aktoerregister


### PR DESCRIPTION
* Fra saf-scope til dokdistfordeling-scope for dokdistfordeling integrasjonen
* Introdusert ny config `DOKDISTFORDELING_SCOPE`
* Endret `dokdistfordeling` client registration til å bruke `DOKDISTFORDELING_SCOPE` i stedet for `SAF_SCOPE`

> Vi gjør endringer på autentisering i dokdistfordeling, for å sørge for at autentisering med EntraID er implementert som tiltenkt. Pr i dag kalles distribuerJournalpost med EntraID tokens scopet mot SAF, hvor dokdistfordeling proxyer dette tokenet videre i kall til SAF. Vi ønsker på sikt å endre dette til av dokdistfordeling kun kan kalles med tokens som er scopet mot seg selv. Steg 1 av denne endringen innføres nå, hvor dokdistfordeling i en overgangsperiode vil akseptere tokens med enten saf- eller dokdistfordeling-scope. Dette innebærer at konsumenter ikke trenger å gjøre noe umiddelbart, men på sikt (helst så snart som mulig) må endre scope for tokenet de kaller dokdistfordeling med. Vi kommer til å bistå konsumenter med denne endringen. Liste med pre-autentiserte applikasjoner er populert for hvert miljø basert på kall mot distribuertJournalpost siste 7 dager.

Har dobbeltsjekket dokdistfordeling config og `prod-fss:bidrag:bidrag-dokument-arkiv` ligger inne i dokdistfordeling sin preauthorized liste. Så dere skal ikke merke noe. 🙇